### PR TITLE
Add sessionvision tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
+import Script from "next/script";
 import "./globals.css";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -53,6 +54,10 @@ export default function RootLayout({
           </header>
           <main>{children}</main>
         </div>
+        <Script id="sessionvision-init" strategy="afterInteractive">{`
+          !function(){"use strict";!function(s,n){const t=n.sessionvision;if(t&&t.__SV)return;const e={_i:[],_q:[],init:function(n,t){e._i.push([n,t]);const i=["capture","identify","reset","getDistinctId","register","registerOnce"];for(const s of i)e[s]=function(...n){e._q.push([s,...n])};const o=s.createElement("script");o.async=!0,o.src=(t?.apiHost||"https://cdn.sessionvision.com")+"/"+(t?.version||"latest")+"/sessionvision.min.js";const c=s.getElementsByTagName("script")[0];c&&c.parentNode?c.parentNode.insertBefore(o,c):s.head.appendChild(o)}};n.sessionvision=e}(document,window)}();
+          sessionvision.init('sv_pub_8tQbUJS0E5eKvhd1HCT80idedQmw669f9V3xqGNfMg8');
+        `}</Script>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,13 +22,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <Script id="sessionvision-init" strategy="afterInteractive">{`
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+        <Script id="sessionvision-init" strategy="beforeInteractive">{`
           !function(){"use strict";!function(s,n){const t=n.sessionvision;if(t&&t.__SV)return;const e={_i:[],_q:[],init:function(n,t){e._i.push([n,t]);const i=["capture","identify","reset","getDistinctId","register","registerOnce"];for(const s of i)e[s]=function(...n){e._q.push([s,...n])};const o=s.createElement("script");o.async=!0,o.src=(t?.apiHost||"https://cdn.sessionvision.com")+"/"+(t?.version||"latest")+"/sessionvision.min.js";const c=s.getElementsByTagName("script")[0];c&&c.parentNode?c.parentNode.insertBefore(o,c):s.head.appendChild(o)}};n.sessionvision=e}(document,window)}();
           sessionvision.init('sv_pub_8tQbUJS0E5eKvhd1HCT80idedQmw669f9V3xqGNfMg8');
         `}</Script>
-      </head>
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <div className="mx-auto max-w-2xl px-6 py-12">
           <header className="mb-16 flex items-center justify-between">
             <Link

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,6 +22,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <Script id="sessionvision-init" strategy="afterInteractive">{`
+          !function(){"use strict";!function(s,n){const t=n.sessionvision;if(t&&t.__SV)return;const e={_i:[],_q:[],init:function(n,t){e._i.push([n,t]);const i=["capture","identify","reset","getDistinctId","register","registerOnce"];for(const s of i)e[s]=function(...n){e._q.push([s,...n])};const o=s.createElement("script");o.async=!0,o.src=(t?.apiHost||"https://cdn.sessionvision.com")+"/"+(t?.version||"latest")+"/sessionvision.min.js";const c=s.getElementsByTagName("script")[0];c&&c.parentNode?c.parentNode.insertBefore(o,c):s.head.appendChild(o)}};n.sessionvision=e}(document,window)}();
+          sessionvision.init('sv_pub_8tQbUJS0E5eKvhd1HCT80idedQmw669f9V3xqGNfMg8');
+        `}</Script>
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <div className="mx-auto max-w-2xl px-6 py-12">
           <header className="mb-16 flex items-center justify-between">
@@ -54,10 +60,6 @@ export default function RootLayout({
           </header>
           <main>{children}</main>
         </div>
-        <Script id="sessionvision-init" strategy="afterInteractive">{`
-          !function(){"use strict";!function(s,n){const t=n.sessionvision;if(t&&t.__SV)return;const e={_i:[],_q:[],init:function(n,t){e._i.push([n,t]);const i=["capture","identify","reset","getDistinctId","register","registerOnce"];for(const s of i)e[s]=function(...n){e._q.push([s,...n])};const o=s.createElement("script");o.async=!0,o.src=(t?.apiHost||"https://cdn.sessionvision.com")+"/"+(t?.version||"latest")+"/sessionvision.min.js";const c=s.getElementsByTagName("script")[0];c&&c.parentNode?c.parentNode.insertBefore(o,c):s.head.appendChild(o)}};n.sessionvision=e}(document,window)}();
-          sessionvision.init('sv_pub_8tQbUJS0E5eKvhd1HCT80idedQmw669f9V3xqGNfMg8');
-        `}</Script>
       </body>
     </html>
   );


### PR DESCRIPTION
Restore session analytics tracking that was removed during the site rebuild.

The sessionvision tracking script is added to the Next.js root layout with `afterInteractive` strategy to avoid blocking page rendering. This uses the same public key as the previous implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)